### PR TITLE
RLIB-13: Install python scripts into pyexecdir instead of pythondir

### DIFF
--- a/bindings/interfaces/Makefile.am
+++ b/bindings/interfaces/Makefile.am
@@ -26,4 +26,4 @@ EXTRA_DIST = rlib.pm rlibcompat.py rlib.java  rlibJNI.java  SWIGTYPE_p_f_p_rlib_
 perldir = $(PERL_EXTENSION_DIR)
 perl_DATA = rlib.pm
 
-python_DATA = rlibcompat.py rlib.py
+pyexec_DATA = rlibcompat.py rlib.py

--- a/configure.ac
+++ b/configure.ac
@@ -658,7 +658,9 @@ rlib-$VERSION:
      PHP entension dir:      ${PHP_EXTENSION_DIR}
     PYTHON:                  ${enable_python}
      PYTHON version:         ${PYTHON_VERSION}
+     PYTHON script dir:      ${pythondir}
      PYTHON entension dir:   ${pyexecdir}
+     PYTHON module dir:      ${pkgpyexecdir}
     JAVA:                    ${enable_java}
     CSHARP:                  ${enable_csharp}
     PERL:                    ${enable_perl}


### PR DESCRIPTION
for multilib packaging.