### PR TITLE
RLIB-24: First attempt at fixing HTML output with relative image URLs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,9 @@ src/examples/c/products.xml
 src/examples/c/relprt
 src/examples/c/relprt.exe
 src/examples/c/relpth1
+src/examples/c/relpth1-gen
 src/examples/c/relpth1.exe
+src/examples/c/relpth1-gen.exe
 src/examples/c/relpth2
 src/examples/c/relpth2.exe
 src/examples/c/srcpth

--- a/libsrc/csv_data_source.c
+++ b/libsrc/csv_data_source.c
@@ -211,7 +211,7 @@ void * csv_new_result_from_query(gpointer input_ptr, gpointer query_ptr) {
 
 	INPUT_PRIVATE(input)->error = "";
 
-	file = get_filename(input->r, query->sql, -1, FALSE);
+	file = get_filename(input->r, query->sql, -1, FALSE, FALSE);
 	fd = open(file, O_RDONLY, 6);
 	g_free(file);
 	if(fd > 0) {

--- a/libsrc/layout.c
+++ b/libsrc/layout.c
@@ -285,7 +285,7 @@ static gfloat rlib_layout_text_from_extra_data(rlib *r, gint backwards, gfloat l
 		gfloat width = RLIB_FXP_TO_NORMAL_LONG_LONG(RLIB_VALUE_GET_AS_NUMBER(&extra_data->rval_image_width));
 		gchar *name = RLIB_VALUE_GET_AS_STRING(&extra_data->rval_image_name);
 		gchar *type = RLIB_VALUE_GET_AS_STRING(&extra_data->rval_image_type);
-		filename = get_filename(r, name, extra_data->report_index, FALSE);
+		filename = get_filename(r, name, extra_data->report_index, FALSE, use_relative_filename(r));
 		OUTPUT(r)->line_image(r, left_origin, bottom_orgin, filename, type, width, height);
 		g_free(filename);
 		rtn_width = extra_data->output_width;
@@ -295,7 +295,7 @@ static gfloat rlib_layout_text_from_extra_data(rlib *r, gint backwards, gfloat l
 		gfloat width = RLIB_FXP_TO_NORMAL_LONG_LONG(RLIB_VALUE_GET_AS_NUMBER(&extra_data->rval_image_width));
 		gchar *name = RLIB_VALUE_GET_AS_STRING(&extra_data->rval_image_name);
 		gchar *type = RLIB_VALUE_GET_AS_STRING(&extra_data->rval_image_type);
-		filename = get_filename(r, name, extra_data->report_index, FALSE);
+		filename = get_filename(r, name, extra_data->report_index, FALSE, use_relative_filename(r));
 		OUTPUT(r)->line_image(r, left_origin, bottom_orgin, filename, type, width, height);
 		g_free(filename);
 		rtn_width = extra_data->output_width;
@@ -1085,7 +1085,7 @@ static gint rlib_layout_report_output_array(rlib *r, struct rlib_part *part, str
 								gfloat width1 = RLIB_FXP_TO_NORMAL_LONG_LONG(RLIB_VALUE_GET_AS_NUMBER(&extra_data[count].rval_image_width));
 								gchar *name = RLIB_VALUE_GET_AS_STRING(&extra_data[count].rval_image_name);
 								gchar *type = RLIB_VALUE_GET_AS_STRING(&extra_data[count].rval_image_type);
-								filename = get_filename(r, name, part->report_index, FALSE);
+								filename = get_filename(r, name, part->report_index, FALSE, use_relative_filename(r));
 								OUTPUT(r)->line_image(r, margin, layout_get_next_line(part, *rlib_position, rl), filename, type, width1, height1);
 								g_free(filename);
 								width = RLIB_GET_LINE(width1);
@@ -1095,7 +1095,7 @@ static gint rlib_layout_report_output_array(rlib *r, struct rlib_part *part, str
 								gfloat width1 = RLIB_FXP_TO_NORMAL_LONG_LONG(RLIB_VALUE_GET_AS_NUMBER(&extra_data[count].rval_image_width));
 								gchar *name = RLIB_VALUE_GET_AS_STRING(&extra_data[count].rval_image_name);
 								gchar *type = RLIB_VALUE_GET_AS_STRING(&extra_data[count].rval_image_type);
-								filename = get_filename(r, name, part->report_index, FALSE);
+								filename = get_filename(r, name, part->report_index, FALSE, use_relative_filename(r));
 								OUTPUT(r)->line_image(r, margin, layout_get_next_line(part, *rlib_position, rl), filename, type, width1, height1);
 								g_free(filename);
 								width = RLIB_GET_LINE(width1);
@@ -1194,7 +1194,7 @@ static gint rlib_layout_report_output_array(rlib *r, struct rlib_part *part, str
 				gchar *type = RLIB_VALUE_GET_AS_STRING(rval_type);
 				gchar *filename;
 				output_count++;
-				filename = get_filename(r, name, part->report_index, FALSE);
+				filename = get_filename(r, name, part->report_index, FALSE, use_relative_filename(r));
 				OUTPUT(r)->background_image(r, my_left_margin, layout_get_next_line_by_font_point(part, *rlib_position, height1), filename,
 					type, width1, height1);
 				g_free(filename);

--- a/libsrc/parsexml.c
+++ b/libsrc/parsexml.c
@@ -1260,7 +1260,7 @@ struct rlib_part *parse_part_file(rlib *r, gboolean allow_fail, int report_index
 	if(type == RLIB_REPORT_TYPE_BUFFER)
 		doc = xmlReadMemory(filename, strlen(filename), NULL, NULL, XML_PARSE_XINCLUDE);
 	else {
-		gchar *file = get_filename(r, filename, report_index, TRUE);
+		gchar *file = get_filename(r, filename, report_index, TRUE, FALSE);
 		doc = xmlReadFile(file, NULL, XML_PARSE_XINCLUDE);
 		g_free(file);
 	}
@@ -1372,7 +1372,7 @@ static struct rlib_report *parse_report_file(rlib *r, gboolean allow_fail, int r
 
 	xmlLineNumbersDefault(1);
 
-	file = get_filename(r, filename, report_index, FALSE);
+	file = get_filename(r, filename, report_index, FALSE, FALSE);
 	doc = xmlReadFile(file, NULL, XML_PARSE_XINCLUDE);
 	g_free(file);
 

--- a/libsrc/rlib-internal.h
+++ b/libsrc/rlib-internal.h
@@ -968,7 +968,8 @@ gint64 rlib_fxp_div(gint64 num, gint64 denom, gint places);
 
 /***** PROTOTYPES: api.c ******************************************************/
 void rlib_trap(void); /* For internals debugging only */
-gchar * get_filename(rlib *r, const char *filename, int report_index, gboolean report); /* not an exported API, no rlib_ prefix */
+gboolean use_relative_filename(rlib *r);
+gchar * get_filename(rlib *r, const char *filename, int report_index, gboolean report, gboolean use_as_is); /* not an exported API, no rlib_ prefix */
 struct rlib_query *rlib_alloc_query_space(rlib *r);
 
 /***** PROTOTYPES: parsexml.c *************************************************/

--- a/libsrc/xml_data_source.c
+++ b/libsrc/xml_data_source.c
@@ -189,7 +189,7 @@ static void *xml_new_result_from_query(gpointer input_ptr, gpointer query_ptr) {
 	xmlDocPtr doc;
 	gchar *file;
 
-	file = get_filename(input->r, query->sql, -1, FALSE);
+	file = get_filename(input->r, query->sql, -1, FALSE, FALSE);
 	doc = xmlReadFile(file, NULL, XML_PARSE_XINCLUDE);
 	g_free(file);
 

--- a/src/examples/c/Makefile.am
+++ b/src/examples/c/Makefile.am
@@ -22,7 +22,7 @@
 
 noinst_PROGRAMS = \
 	example_mysql example_pg example_odbc \
-	relpth1 relpth2 srcpth relprt graph
+	relpth1 relpth1-gen relpth2 srcpth relprt graph
 
 AM_CFLAGS = $(RLIB_CFLAGS) -I${top_srcdir}/libsrc
 
@@ -33,6 +33,8 @@ example_pg_LDADD = $(top_builddir)/libsrc/libr.la
 example_odbc_LDADD = $(top_builddir)/libsrc/libr.la
 
 relpth1_LDADD = $(top_builddir)/libsrc/libr.la
+
+relpth1_gen_LDADD = $(top_builddir)/libsrc/libr.la
 
 relpth2_LDADD = $(top_builddir)/libsrc/libr.la
 

--- a/src/examples/c/relpth1-gen.c
+++ b/src/examples/c/relpth1-gen.c
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2016 SICOM Systems, INC.
+ *
+ *  Author: Zoltán Böszörményi <zboszormenyi@sicom.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <rlib.h>
+
+int main(void) {
+	struct stat st;
+	char *buf;
+	int fd;
+	rlib *r;
+
+	stat("relpath/relpath.xml", &st);
+
+	buf = malloc(st.st_size + 1);
+
+	fd = open("relpath/relpath.xml", O_RDONLY);
+	read(fd, buf, st.st_size);
+	close(fd);
+
+	buf[st.st_size] = '\0';
+
+	r = rlib_init();
+	rlib_add_search_path(r, "relpath");
+	rlib_add_report_from_buffer(r, buf);
+	rlib_set_output_format(r, RLIB_FORMAT_HTML);
+	rlib_execute(r);
+	rlib_spool(r);
+	rlib_free(r);
+
+	free(buf);
+
+	return 0;
+}


### PR DESCRIPTION
The recent change to look for files relative to the report XML and using the full path for the validated files broke HTML output that really expect relative URLs to work.