### PR TITLE
RLIB-28: Fix Safari display with all spaces in a <span>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ dnl Report bugs to rlib-devel@lists.sourceforge.net
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([rlib],[2.0.14],[http://bugzilla.sicompos.com])
+AC_INIT([rlib],[2.0.15],[http://bugzilla.sicompos.com])
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR(libsrc/rlib.h)
 AC_CONFIG_MACRO_DIR([m4])
@@ -30,12 +30,12 @@ AM_INIT_AUTOMAKE()
 AC_CONFIG_HEADERS(config.h)
 AM_MAINTAINER_MODE
 
-RLIB_VERSION=2.0.10
+RLIB_VERSION=2.0.15
 AC_SUBST(RLIB_VERSION)
 
 RLIB_LT_CURRENT=4
 RLIB_LT_AGE=3
-RLIB_LT_REVISION=14
+RLIB_LT_REVISION=15
 AC_SUBST(RLIB_LT_CURRENT)
 AC_SUBST(RLIB_LT_REVISION)
 AC_SUBST(RLIB_LT_AGE)

--- a/libsrc/html.c
+++ b/libsrc/html.c
@@ -210,7 +210,7 @@ static void html_print_text(rlib *r, gfloat left_origin UNUSED, gfloat bottom_or
 	}
 
 	if (only_spaces) {
-		g_string_append(string, "&nbsp");
+		g_string_append(string, "&nbsp;");
 		g_string_append(string, escaped + 1);
 	} else
 		g_string_append(string, escaped);

--- a/libsrc/html.c
+++ b/libsrc/html.c
@@ -23,11 +23,14 @@
  * formatted report from the rlib object.
  *
  */
+
+#include <config.h>
+
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
-#include <config.h>
 #include "rlib-internal.h"
 #include "rlib_gd.h"
 
@@ -178,6 +181,9 @@ static gchar *get_html_color(gchar *str, struct rlib_rgb *color) {
 
 static void html_print_text(rlib *r, gfloat left_origin UNUSED, gfloat bottom_origin UNUSED, const gchar *text, gint backwards, struct rlib_line_extra_data *extra_data) {
 	GString *string = g_string_new("");
+	gchar *escaped;
+	gint pos;
+	gboolean only_spaces = TRUE;
 
 	g_string_append_printf(string, "<span data-col=\"%d\" data-width=\"%d\" style=\"font-size: %dpx; ", extra_data->col, extra_data->width, BIGGER_HTML_FONT(extra_data->font_point));
 
@@ -189,11 +195,25 @@ static void html_print_text(rlib *r, gfloat left_origin UNUSED, gfloat bottom_or
 		g_string_append(string, "font-weight: bold;");
 	if(extra_data->is_italics == TRUE)
 		g_string_append(string, "font-style: italic;");
-
 		
 	g_string_append(string,"\">");
-	gchar *escaped = g_markup_escape_text(text, strlen(text));
-	g_string_append(string, escaped);
+	escaped = g_markup_escape_text(text, strlen(text));
+	for (pos = 0; escaped[pos]; pos++) {
+#if 0
+		if (!isspace(escaped[pos])) {
+#else
+		if (escaped[pos] != ' ') {
+#endif
+			only_spaces = FALSE;
+			break;
+		}
+	}
+
+	if (only_spaces) {
+		g_string_append(string, "&nbsp");
+		g_string_append(string, escaped + 1);
+	} else
+		g_string_append(string, escaped);
 	g_string_append(string, "</span>");
 	g_free(escaped);
 


### PR DESCRIPTION
Browsers on iPhone must use the Safari engine, which collapses strings that contain only breaking spaces into a single space. Replacing the first space with nbsp is enough to fix this problem.