### PR TITLE
Fix empty strings after 2.0.15+ in the HTML output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ src/examples/c/srcpth
 src/examples/c/srcpth.exe
 src/examples/c/graph
 src/examples/c/graph.exe
+src/examples/c/empty-string
+src/examples/c/empty-string.exe
 src/examples/csharp/products.xml
 src/examples/java/*.java
 src/examples/java/*.xml
@@ -91,6 +93,7 @@ inputs/odbc/libr-odbc.def
 inputs/postgres/libr-postgres.def
 
 *.pdf
+*.html
 
 bindings/php/build
 bindings/php/modules

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ dnl Report bugs to rlib-devel@lists.sourceforge.net
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([rlib],[2.0.16],[http://bugzilla.sicompos.com])
+AC_INIT([rlib],[2.0.17],[http://bugzilla.sicompos.com])
 AC_CANONICAL_TARGET
 AC_CONFIG_SRCDIR(libsrc/rlib.h)
 AC_CONFIG_MACRO_DIR([m4])
@@ -32,7 +32,7 @@ AM_MAINTAINER_MODE
 
 RLIB_LT_CURRENT=4
 RLIB_LT_AGE=3
-RLIB_LT_REVISION=16
+RLIB_LT_REVISION=17
 AC_SUBST(RLIB_LT_CURRENT)
 AC_SUBST(RLIB_LT_REVISION)
 AC_SUBST(RLIB_LT_AGE)

--- a/libsrc/html.c
+++ b/libsrc/html.c
@@ -196,7 +196,7 @@ static void html_print_text(rlib *r, gfloat left_origin UNUSED, gfloat bottom_or
 		g_string_append(string, "font-weight: bold;");
 	if(extra_data->is_italics == TRUE)
 		g_string_append(string, "font-style: italic;");
-		
+
 	g_string_append(string,"\">");
 	escaped = g_markup_escape_text(text, strlen(text));
 	for (pos = 0; escaped[pos]; pos++) {
@@ -210,7 +210,7 @@ static void html_print_text(rlib *r, gfloat left_origin UNUSED, gfloat bottom_or
 		}
 	}
 
-	if (only_spaces) {
+	if (only_spaces && pos) {
 		g_string_append(string, "&nbsp;");
 		g_string_append(string, escaped + 1);
 	} else

--- a/libsrc/resolution.c
+++ b/libsrc/resolution.c
@@ -547,13 +547,13 @@ void rlib_resolve_part_fields(rlib *r, struct rlib_part *part) {
 	rlib_resolve_outputs(r, part, NULL, part->report_header);
 }
 
-gchar * rlib_resolve_memory_variable(rlib *r, gchar *name) {
-	if(r_strlen(name) >= 3 && name[0] == 'm' && name[1] == '.') {
+gchar *rlib_resolve_memory_variable(rlib *r, gchar *name) {
+	if (r_strlen(name) >= 3 && name[0] == 'm' && name[1] == '.') {
 		gchar *value;
-		value = g_hash_table_lookup(r->parameters, name+2);
-		if(value != NULL)
-			return g_strdup(value);
-		return ENVIRONMENT(r)->rlib_resolve_memory_variable(name+2);
+		value = g_hash_table_lookup(r->parameters, name + 2);
+		if (value != NULL)
+			return value;
+		return ENVIRONMENT(r)->rlib_resolve_memory_variable(name + 2);
 	}
 	return NULL;
 }

--- a/src/examples/c/Makefile.am
+++ b/src/examples/c/Makefile.am
@@ -22,7 +22,8 @@
 
 noinst_PROGRAMS = \
 	example_mysql example_pg example_odbc \
-	relpth1 relpth1-gen relpth2 srcpth relprt graph
+	relpth1 relpth1-gen relpth2 srcpth relprt graph \
+	empty-string
 
 AM_CFLAGS = $(RLIB_CFLAGS) -I${top_srcdir}/libsrc
 
@@ -43,6 +44,8 @@ srcpth_LDADD = $(top_builddir)/libsrc/libr.la
 relprt_LDADD = $(top_builddir)/libsrc/libr.la
 
 graph_LDADD = $(top_builddir)/libsrc/libr.la
+
+empty_string_LDADD = $(top_builddir)/libsrc/libr.la
 
 noinst_SCRIPTS = products.xml
 

--- a/src/examples/c/empty-string.c
+++ b/src/examples/c/empty-string.c
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2017 SICOM Systems, INC.
+ *
+ *  Author: Zoltán Böszörményi <zboszormenyi@sicom.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of version 2 of the GNU General Public
+ * License as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <rlib.h>
+#include <rlib_input.h>
+
+int main(int argc, char **argv) {
+	const char *array[2][1] = {
+		[0][0] = "field",
+		[1][0] = ""
+	};
+	rlib *r;
+
+	r = rlib_init();
+	rlib_add_datasource_array(r, "arrays"); 
+	rlib_add_query_array_as(r, "arrays", array, 2, 1, "data");
+	rlib_add_report(r, "emptystr.xml");
+	rlib_add_parameter(r, "param", "");
+	if (argc >= 2)
+		rlib_set_output_format_from_text(r, argv[1]);
+	else
+		rlib_set_output_format_from_text(r, "pdf");
+	rlib_execute(r);
+	rlib_spool(r);
+	rlib_free(r);
+	return 0;
+}

--- a/src/examples/c/emptystr.xml
+++ b/src/examples/c/emptystr.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!DOCTYPE report >
+<Report fontSize="9" orientation="portrait">
+	<ReportHeader>
+		<Output>
+			<Line/>
+			<Line fontSize="12">
+				<literal>Empty string from memory variable:</literal>
+				<field value="m.param" />
+			</Line>
+			<Line fontsize="4"/>
+			<HorizontalLine size="4" bgcolor="'white'"/>
+			<HorizontalLine size="2" bgcolor="'black'"/>
+			<HorizontalLine size="4" bgcolor="'white'"/>
+		</Output>
+	</ReportHeader>
+
+	<Detail>
+		<FieldHeaders>
+			<Output>
+				<HorizontalLine size="1" bgcolor="'black'"/>
+				<Line bgcolor="'0xe5e5e5'">
+					<literal width="15" col="1">Field</literal>
+				</Line>
+				<HorizontalLine size="1" bgcolor="'black'"/>
+				<HorizontalLine size="4" bgcolor="'white'"/>
+			</Output>
+		</FieldHeaders>
+		<FieldDetails>
+			<Output>
+				<Line bgcolor="iif(r.detailcnt%2,'0xe5e5e5','white')">
+					<field value="data.field" width="15" align="left" col="1"/>
+				</Line>
+				<HorizontalLine size="1" bgcolor="'black'"/>
+				<HorizontalLine size="4" bgcolor="'white'"/>
+			</Output>
+		</FieldDetails>
+	</Detail>
+</Report>


### PR DESCRIPTION
Avoid garbage in the HTML output when strings are empty.
Fixed a memory leak when rlib_add_parameter() is used and the parameter is referenced as a memory variable.
Added a test case for exercising empty strings from data fields and memory variables.