### PR TITLE
RLIB-33: Allow context based and plural translations

### DIFF
--- a/libsrc/formatstring.c
+++ b/libsrc/formatstring.c
@@ -378,7 +378,7 @@ gint rlib_format_string(rlib *r, gchar **dest, struct rlib_report_field *rf, str
 	return TRUE;
 }
 
-gchar *rlib_align_text(rlib *r, gchar **my_rtn, gchar *src, gint align, gint width) {
+gchar *rlib_align_text(rlib *r, gchar **my_rtn, const gchar *src, gint align, gint width) {
 	gint len = 0, size = 0, lastidx = 0;
 	gchar *rtn;
 

--- a/libsrc/free.c
+++ b/libsrc/free.c
@@ -93,6 +93,8 @@ static void rlib_text_free_pcode(rlib *r, struct rlib_report_literal *rt) {
 	xmlFree(rt->xml_italics.xml);
 	xmlFree(rt->xml_link.xml);
 	xmlFree(rt->xml_translate.xml);
+	xmlFree(rt->xml_translatectx.xml);
+	xmlFree(rt->xml_translateplural.xml);
 	xmlFree(rt->xml_col.xml);
 	g_free(rt);
 }
@@ -123,6 +125,8 @@ static void rlib_field_free_pcode(rlib *r, struct rlib_report_field *rf) {
 	xmlFree(rf->xml_format.xml);
 	xmlFree(rf->xml_link.xml);
 	xmlFree(rf->xml_translate.xml);
+	xmlFree(rf->xml_translatectx.xml);
+	xmlFree(rf->xml_translateplural.xml);
 	xmlFree(rf->xml_col.xml);
 	xmlFree(rf->xml_delayed.xml);
 	xmlFree(rf->xml_memo.xml);

--- a/libsrc/gettext.h
+++ b/libsrc/gettext.h
@@ -1,0 +1,292 @@
+/* Convenience header for conditional use of GNU <libintl.h>.
+   Copyright (C) 1995-1998, 2000-2002, 2004-2006, 2009-2016 Free Software
+   Foundation, Inc.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef _LIBGETTEXT_H
+#define _LIBGETTEXT_H 1
+
+/* NLS can be disabled through the configure --disable-nls option.  */
+#if ENABLE_NLS
+
+/* Get declarations of GNU message catalog functions.  */
+# include <libintl.h>
+
+/* You can set the DEFAULT_TEXT_DOMAIN macro to specify the domain used by
+   the gettext() and ngettext() macros.  This is an alternative to calling
+   textdomain(), and is useful for libraries.  */
+# ifdef DEFAULT_TEXT_DOMAIN
+#  undef gettext
+#  define gettext(Msgid) \
+     dgettext (DEFAULT_TEXT_DOMAIN, Msgid)
+#  undef ngettext
+#  define ngettext(Msgid1, Msgid2, N) \
+     dngettext (DEFAULT_TEXT_DOMAIN, Msgid1, Msgid2, N)
+# endif
+
+#else
+
+/* Solaris /usr/include/locale.h includes /usr/include/libintl.h, which
+   chokes if dcgettext is defined as a macro.  So include it now, to make
+   later inclusions of <locale.h> a NOP.  We don't include <libintl.h>
+   as well because people using "gettext.h" will not include <libintl.h>,
+   and also including <libintl.h> would fail on SunOS 4, whereas <locale.h>
+   is OK.  */
+#if defined(__sun)
+# include <locale.h>
+#endif
+
+/* Many header files from the libstdc++ coming with g++ 3.3 or newer include
+   <libintl.h>, which chokes if dcgettext is defined as a macro.  So include
+   it now, to make later inclusions of <libintl.h> a NOP.  */
+#if defined(__cplusplus) && defined(__GNUG__) && (__GNUC__ >= 3)
+# include <cstdlib>
+# if (__GLIBC__ >= 2 && !defined __UCLIBC__) || _GLIBCXX_HAVE_LIBINTL_H
+#  include <libintl.h>
+# endif
+#endif
+
+/* Disabled NLS.
+   The casts to 'const char *' serve the purpose of producing warnings
+   for invalid uses of the value returned from these functions.
+   On pre-ANSI systems without 'const', the config.h file is supposed to
+   contain "#define const".  */
+# undef gettext
+# define gettext(Msgid) ((const char *) (Msgid))
+# undef dgettext
+# define dgettext(Domainname, Msgid) ((void) (Domainname), gettext (Msgid))
+# undef dcgettext
+# define dcgettext(Domainname, Msgid, Category) \
+    ((void) (Category), dgettext (Domainname, Msgid))
+# undef ngettext
+# define ngettext(Msgid1, Msgid2, N) \
+    ((N) == 1 \
+     ? ((void) (Msgid2), (const char *) (Msgid1)) \
+     : ((void) (Msgid1), (const char *) (Msgid2)))
+# undef dngettext
+# define dngettext(Domainname, Msgid1, Msgid2, N) \
+    ((void) (Domainname), ngettext (Msgid1, Msgid2, N))
+# undef dcngettext
+# define dcngettext(Domainname, Msgid1, Msgid2, N, Category) \
+    ((void) (Category), dngettext (Domainname, Msgid1, Msgid2, N))
+# undef textdomain
+# define textdomain(Domainname) ((const char *) (Domainname))
+# undef bindtextdomain
+# define bindtextdomain(Domainname, Dirname) \
+    ((void) (Domainname), (const char *) (Dirname))
+# undef bind_textdomain_codeset
+# define bind_textdomain_codeset(Domainname, Codeset) \
+    ((void) (Domainname), (const char *) (Codeset))
+
+#endif
+
+/* Prefer gnulib's setlocale override over libintl's setlocale override.  */
+#ifdef GNULIB_defined_setlocale
+# undef setlocale
+# define setlocale rpl_setlocale
+#endif
+
+/* A pseudo function call that serves as a marker for the automated
+   extraction of messages, but does not call gettext().  The run-time
+   translation is done at a different place in the code.
+   The argument, String, should be a literal string.  Concatenated strings
+   and other string expressions won't work.
+   The macro's expansion is not parenthesized, so that it is suitable as
+   initializer for static 'char[]' or 'const char[]' variables.  */
+#define gettext_noop(String) String
+
+/* The separator between msgctxt and msgid in a .mo file.  */
+#define GETTEXT_CONTEXT_GLUE "\004"
+
+/* Pseudo function calls, taking a MSGCTXT and a MSGID instead of just a
+   MSGID.  MSGCTXT and MSGID must be string literals.  MSGCTXT should be
+   short and rarely need to change.
+   The letter 'p' stands for 'particular' or 'special'.  */
+#ifdef DEFAULT_TEXT_DOMAIN
+# define pgettext(Msgctxt, Msgid) \
+   pgettext_aux (DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
+#else
+# define pgettext(Msgctxt, Msgid) \
+   pgettext_aux (NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
+#endif
+#define dpgettext(Domainname, Msgctxt, Msgid) \
+  pgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, LC_MESSAGES)
+#define dcpgettext(Domainname, Msgctxt, Msgid, Category) \
+  pgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, Category)
+#ifdef DEFAULT_TEXT_DOMAIN
+# define npgettext(Msgctxt, Msgid, MsgidPlural, N) \
+   npgettext_aux (DEFAULT_TEXT_DOMAIN, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
+#else
+# define npgettext(Msgctxt, Msgid, MsgidPlural, N) \
+   npgettext_aux (NULL, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
+#endif
+#define dnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N) \
+  npgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define dcnpgettext(Domainname, Msgctxt, Msgid, MsgidPlural, N, Category) \
+  npgettext_aux (Domainname, Msgctxt GETTEXT_CONTEXT_GLUE Msgid, Msgid, MsgidPlural, N, Category)
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+static const char *
+pgettext_aux (const char *domain,
+              const char *msg_ctxt_id, const char *msgid,
+              int category)
+{
+  const char *translation = dcgettext (domain, msg_ctxt_id, category);
+  if (translation == msg_ctxt_id)
+    return msgid;
+  else
+    return translation;
+}
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+static const char *
+npgettext_aux (const char *domain,
+               const char *msg_ctxt_id, const char *msgid,
+               const char *msgid_plural, unsigned long int n,
+               int category)
+{
+  const char *translation =
+    dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+  if (translation == msg_ctxt_id || translation == msgid_plural)
+    return (n == 1 ? msgid : msgid_plural);
+  else
+    return translation;
+}
+
+/* The same thing extended for non-constant arguments.  Here MSGCTXT and MSGID
+   can be arbitrary expressions.  But for string literals these macros are
+   less efficient than those above.  */
+
+#include <string.h>
+
+#if (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
+     /* || __STDC_VERSION__ >= 199901L */ )
+# define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
+#else
+# define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0
+#endif
+
+#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
+#include <stdlib.h>
+#endif
+
+#define pgettext_expr(Msgctxt, Msgid) \
+  dcpgettext_expr (NULL, Msgctxt, Msgid, LC_MESSAGES)
+#define dpgettext_expr(Domainname, Msgctxt, Msgid) \
+  dcpgettext_expr (Domainname, Msgctxt, Msgid, LC_MESSAGES)
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+static const char *
+dcpgettext_expr (const char *domain,
+                 const char *msgctxt, const char *msgid,
+                 int category)
+{
+  size_t msgctxt_len = strlen (msgctxt) + 1;
+  size_t msgid_len = strlen (msgid) + 1;
+  const char *translation;
+#if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
+  char msg_ctxt_id[msgctxt_len + msgid_len];
+#else
+  char buf[1024];
+  char *msg_ctxt_id =
+    (msgctxt_len + msgid_len <= sizeof (buf)
+     ? buf
+     : (char *) malloc (msgctxt_len + msgid_len));
+  if (msg_ctxt_id != NULL)
+#endif
+    {
+      int found_translation;
+      memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
+      msg_ctxt_id[msgctxt_len - 1] = '\004';
+      memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+      translation = dcgettext (domain, msg_ctxt_id, category);
+      found_translation = (translation != msg_ctxt_id);
+#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
+      if (msg_ctxt_id != buf)
+        free (msg_ctxt_id);
+#endif
+      if (found_translation)
+        return translation;
+    }
+  return msgid;
+}
+
+#define npgettext_expr(Msgctxt, Msgid, MsgidPlural, N) \
+  dcnpgettext_expr (NULL, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
+#define dnpgettext_expr(Domainname, Msgctxt, Msgid, MsgidPlural, N) \
+  dcnpgettext_expr (Domainname, Msgctxt, Msgid, MsgidPlural, N, LC_MESSAGES)
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+static const char *
+dcnpgettext_expr (const char *domain,
+                  const char *msgctxt, const char *msgid,
+                  const char *msgid_plural, unsigned long int n,
+                  int category)
+{
+  size_t msgctxt_len = strlen (msgctxt) + 1;
+  size_t msgid_len = strlen (msgid) + 1;
+  const char *translation;
+#if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
+  char msg_ctxt_id[msgctxt_len + msgid_len];
+#else
+  char buf[1024];
+  char *msg_ctxt_id =
+    (msgctxt_len + msgid_len <= sizeof (buf)
+     ? buf
+     : (char *) malloc (msgctxt_len + msgid_len));
+  if (msg_ctxt_id != NULL)
+#endif
+    {
+      int found_translation;
+      memcpy (msg_ctxt_id, msgctxt, msgctxt_len - 1);
+      msg_ctxt_id[msgctxt_len - 1] = '\004';
+      memcpy (msg_ctxt_id + msgctxt_len, msgid, msgid_len);
+      translation = dcngettext (domain, msg_ctxt_id, msgid_plural, n, category);
+      found_translation = !(translation == msg_ctxt_id || translation == msgid_plural);
+#if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
+      if (msg_ctxt_id != buf)
+        free (msg_ctxt_id);
+#endif
+      if (found_translation)
+        return translation;
+    }
+  return (n == 1 ? msgid : msgid_plural);
+}
+
+#endif /* _LIBGETTEXT_H */

--- a/libsrc/parsexml.c
+++ b/libsrc/parsexml.c
@@ -107,6 +107,8 @@ static struct rlib_element * parse_line_array(rlib *r, xmlDocPtr doc, xmlNsPtr n
 			get_both(&f->xml_format, cur, "format");
 			get_both(&f->xml_link, cur, "link");
 			get_both(&f->xml_translate, cur, "translate");
+			get_both(&f->xml_translatectx, cur, "translatectx");
+			get_both(&f->xml_translateplural, cur, "translateplural");
 			get_both(&f->xml_col, cur, "col");
 			get_both(&f->xml_delayed, cur, "delayed");
 			get_both(&f->xml_memo, cur, "memo");
@@ -134,6 +136,8 @@ static struct rlib_element * parse_line_array(rlib *r, xmlDocPtr doc, xmlNsPtr n
 			get_both(&t->xml_italics, cur, "italics");
 			get_both(&t->xml_link, cur, "link");
 			get_both(&t->xml_translate, cur, "translate");
+			get_both(&t->xml_translatectx, cur, "translatectx");
+			get_both(&t->xml_translateplural, cur, "translateplural");
 			get_both(&t->xml_col, cur, "col");
 
 			current->data = t;

--- a/libsrc/resolution.c
+++ b/libsrc/resolution.c
@@ -146,6 +146,8 @@ static void rlib_field_resolve_pcode(rlib *r, struct rlib_part *part, struct rli
 	rf->format_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_format.xml, rf->xml_format.line, TRUE);
 	rf->link_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_link.xml, rf->xml_link.line, TRUE);
 	rf->translate_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_translate.xml, rf->xml_translate.line, TRUE);
+	rf->translatectx_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_translatectx.xml, rf->xml_translatectx.line, TRUE);
+	rf->translateplural_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_translateplural.xml, rf->xml_translateplural.line, TRUE);
 	rf->color_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_color.xml, rf->xml_color.line, TRUE);
 	rf->bgcolor_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_bgcolor.xml, rf->xml_bgcolor.line, TRUE);
 	rf->col_code = rlib_infix_to_pcode(r, part, report, (gchar *)rf->xml_col.xml, rf->xml_col.line, TRUE);
@@ -168,6 +170,8 @@ static void rlib_literal_resolve_pcode(rlib *r, struct rlib_part *part, struct r
 	rt->bgcolor_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_bgcolor.xml, rt->xml_bgcolor.line, TRUE);
 	rt->link_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_link.xml, rt->xml_link.line, TRUE);
 	rt->translate_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_translate.xml, rt->xml_translate.line, TRUE);
+	rt->translatectx_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_translatectx.xml, rt->xml_translatectx.line, TRUE);
+	rt->translateplural_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_translateplural.xml, rt->xml_translateplural.line, TRUE);
 	rt->col_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_col.xml, rt->xml_col.line, TRUE);
 	rt->width_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_width.xml, rt->xml_width.line, TRUE);
 	rt->bold_code = rlib_infix_to_pcode(r, part, report, (gchar *)rt->xml_bold.xml, rt->xml_bold.line, TRUE);

--- a/libsrc/rlib.h
+++ b/libsrc/rlib.h
@@ -172,6 +172,8 @@ struct rlib_report_literal {
 	struct rlib_from_xml xml_col;
 	struct rlib_from_xml xml_link;
 	struct rlib_from_xml xml_translate;
+	struct rlib_from_xml xml_translatectx;
+	struct rlib_from_xml xml_translateplural;
 
 	gint width;
 	gint align;
@@ -185,6 +187,8 @@ struct rlib_report_literal {
 	struct rlib_pcode *align_code;
 	struct rlib_pcode *link_code;
 	struct rlib_pcode *translate_code;
+	struct rlib_pcode *translatectx_code;
+	struct rlib_pcode *translateplural_code;
 };
 
 struct rlib_resultset_field {
@@ -226,6 +230,8 @@ struct rlib_line_extra_data {
 	gint found_bgcolor;
 	gchar *link;
 	gboolean translate;
+	gchar *translatectx;
+	gint translateplural;
 	gint found_link;
 	gint align;
 	struct rlib_rgb color;
@@ -267,6 +273,8 @@ struct rlib_report_field {
 	struct rlib_from_xml xml_format;
 	struct rlib_from_xml xml_link;
 	struct rlib_from_xml xml_translate;
+	struct rlib_from_xml xml_translatectx;
+	struct rlib_from_xml xml_translateplural;
 	struct rlib_from_xml xml_col;
 	struct rlib_from_xml xml_delayed;
 	struct rlib_from_xml xml_memo;
@@ -280,6 +288,8 @@ struct rlib_report_field {
 	struct rlib_pcode *format_code;
 	struct rlib_pcode *link_code;
 	struct rlib_pcode *translate_code;
+	struct rlib_pcode *translatectx_code;
+	struct rlib_pcode *translateplural_code;
 	struct rlib_pcode *color_code;
 	struct rlib_pcode *bgcolor_code;
 	struct rlib_pcode *col_code;
@@ -1027,7 +1037,7 @@ gint rlib_number_sprintf(rlib *r, gchar **dest, gchar *fmtstr, const struct rlib
 gint rlib_format_string(rlib *r, gchar **buf,  struct rlib_report_field *rf, struct rlib_value *rval);
 gint rlib_format_money(rlib *r, gchar **dest, const gchar *moneyformat, gint64 x);
 gint rlib_format_number(rlib *r, gchar **dest, const gchar *moneyformat, gint64 x);
-gchar *rlib_align_text(rlib *r, char **rtn, gchar *src, gint align, gint width);
+gchar *rlib_align_text(rlib *r, char **rtn, const gchar *src, gint align, gint width);
 GSList * rlib_format_split_string(rlib *r, gchar *data, gint width, gint max_lines, gchar new_line, gchar space, gint *line_count);
 
 /***** PROTOTYPES: fxp.c ******************************************************/


### PR DESCRIPTION
Import gettext.h from gettext-0.19.8.1 so strings coming from
the database can be used in context based translations, i.e.
to use the *gettext_expr() macro variants.

Added new XML properties:
* translatectx (expS) and
* translateplural (expN)

To be used in these combinations along with the already existing
toggle translate="yes":

```
                    +----------------------------------+
                    |       translateplural            |
                    +----------------------------------+
                    |       >= 0      | not set or < 0 |
+-------------+-----+-----------------+----------------+
|             | set |dnpgettext_expr()|dpgettext_expr()|
|translatectx +-----+-----------------+----------------+
|             |unset|   dngettext()   |   dgettext()   |
+-------------+-----+-----------------+----------------+
```